### PR TITLE
Enable journald support and remove warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,6 @@
 [Loki][loki] instance or [Grafana Cloud][grafana-cloud]. It is usually deployed
 to every machine that has applications needed to be monitored.
 
-⛔ **Known Issue** - This add-on is waiting on upcoming supervisor functionality
-to function, specifically [this PR](https://github.com/home-assistant/supervisor/pull/2722).
-Once that makes its way into the supervisor release I will update the add-on
-to use the new `journald` config. Until then this add-on cannot scrape logs from
-the system journal as promised. If you choose to use it before that you should set
-`skip_default_scrape_config` to `true` and provide a file for `additional_scrape_configs`
-as it will only be able to see log files created by add-ons.
-
 [![Open your Home Assistant instance and show the add add-on repository dialog
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
 [![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ to every machine that has applications needed to be monitored.
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
 [![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
 
+⚠ This addon requires supervisor version `2021.03.7` to install as it relies on
+the new `journald` capability just added. This is the current beta release as
+of 3/24. If you don't want to join the beta channel, you can wait until it becomes
+the stable release in a couple days.
+
 ## About
 
 By default this addon version of Promtail will tail logs from the systemd

--- a/promtail/.README.j2
+++ b/promtail/.README.j2
@@ -11,6 +11,11 @@
 [Loki][loki] instance or [Grafana Cloud][grafana-cloud]. It is usually deployed
 to every machine that has applications needed to be monitored.
 
+⚠ This addon requires supervisor version `2021.03.7` to install as it relies on
+the new `journald` capability just added. This is the current beta release as
+of 3/24. If you don't want to join the beta channel, you can wait until it becomes
+the stable release in a couple days.
+
 {% set repository = namespace(url='https%3A//github.com/mdegat01/hassio-addons', slug='39bd2704') %}
 {% if channel == "edge" %}
 {% set repository.url = repository.url + '-edge' %}

--- a/promtail/.README.j2
+++ b/promtail/.README.j2
@@ -11,14 +11,6 @@
 [Loki][loki] instance or [Grafana Cloud][grafana-cloud]. It is usually deployed
 to every machine that has applications needed to be monitored.
 
-⛔ **Known Issue** - This add-on is waiting on upcoming supervisor functionality
-to function, specifically [this PR](https://github.com/home-assistant/supervisor/pull/2722).
-Once that makes its way into the supervisor release I will update the add-on
-to use the new `journald` config. Until then this add-on cannot scrape logs from
-the system journal as promised. If you choose to use it before that you should set
-`skip_default_scrape_config` to `true` and provide a file for `additional_scrape_configs`
-as it will only be able to see log files created by add-ons.
-
 {% set repository = namespace(url='https%3A//github.com/mdegat01/hassio-addons', slug='39bd2704') %}
 {% if channel == "edge" %}
 {% set repository.url = repository.url + '-edge' %}

--- a/promtail/DOCS.md
+++ b/promtail/DOCS.md
@@ -113,9 +113,8 @@ the contents of this file:
         __path__: /share/zigbee2mqtt/log/**.txt
 ```
 
-This particular example would cause Promtail to scrape up the log of published
-MQTT messages that the [Zigbee2MQTT add-on][addon-z2m] creates in addition to
-the normal journal logs.
+This particular example would cause Promtail to scrape up the logs MQTT that the
+[Zigbee2MQTT add-on][addon-z2m] makes by default.
 
 Promtail provides a lot of options for configuring scrape configs. See the
 documentation on [scrape_configs][promtail-doc-scrape-configs] for more info on

--- a/promtail/config.json
+++ b/promtail/config.json
@@ -5,6 +5,7 @@
   "slug": "promtail",
   "arch": ["aarch64", "amd64", "armv7"],
   "description": "Promtail for Home Assistant",
+  "journald": true,
   "map": ["share", "ssl"],
   "ports": {
     "9080/tcp": null


### PR DESCRIPTION
Enable journald support! Also add a warning about requiring supervisor version `2021.3.7` to install