### PR TITLE
Update supervisor version required

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ to every machine that has applications needed to be monitored.
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
 [![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
 
-⚠ This addon requires supervisor version `2021.03.7` to install as it relies on
-the new `journald` capability just added. This is the current beta release as
-of 3/24. If you don't want to join the beta channel, you can wait until it becomes
-the stable release in a couple days.
+⚠ This addon requires supervisor version `2021.03.8` as it relies on the new 
+`journald` capability just added. This is the current beta release as of 3/26.
+If you don't want to join the beta channel, you can wait until it becomes the
+stable release in a couple days.
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ to every machine that has applications needed to be monitored.
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
 [![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
 
-⚠ This addon requires supervisor version `2021.03.8` as it relies on the new 
+⚠ This addon requires supervisor version `2021.03.8` as it relies on the new
 `journald` capability just added. This is the current beta release as of 3/26.
 If you don't want to join the beta channel, you can wait until it becomes the
 stable release in a couple days.

--- a/promtail/.README.j2
+++ b/promtail/.README.j2
@@ -11,10 +11,10 @@
 [Loki][loki] instance or [Grafana Cloud][grafana-cloud]. It is usually deployed
 to every machine that has applications needed to be monitored.
 
-⚠ This addon requires supervisor version `2021.03.7` to install as it relies on
-the new `journald` capability just added. This is the current beta release as
-of 3/24. If you don't want to join the beta channel, you can wait until it becomes
-the stable release in a couple days.
+⚠ This addon requires supervisor version `2021.03.8` as it relies on the new
+`journald` capability just added. This is the current beta release as of 3/26.
+If you don't want to join the beta channel, you can wait until it becomes the
+stable release in a couple days.
 
 {% set repository = namespace(url='https%3A//github.com/mdegat01/hassio-addons', slug='39bd2704') %}
 {% if channel == "edge" %}


### PR DESCRIPTION
`2021.3.7` had a bug with the `journald` capability so updating the warning to mention `2021.03.8` is required.