### PR TITLE
Handle volatile journal when used

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -51,8 +51,7 @@ RUN set -eux; \
 
 COPY rootfs /
 RUN set -eux; \
-    mkdir -p /data/promtail; \
-    mkdir -p /var/log/journal;
+    mkdir -p /data/promtail;
 WORKDIR /data/promtail
 
 # Build arguments

--- a/promtail/rootfs/etc/promtail/default-scrape-config.yaml
+++ b/promtail/rootfs/etc/promtail/default-scrape-config.yaml
@@ -5,7 +5,7 @@
     max_age: 12h
     labels:
       job: systemd-journal
-    path: /var/log/journal
+    path: "${JOURNAL_PATH}"
   relabel_configs:
     - source_labels:
         - __journal__systemd_unit

--- a/promtail/rootfs/etc/services.d/promtail/run
+++ b/promtail/rootfs/etc/services.d/promtail/run
@@ -8,21 +8,28 @@
 bashio::log.info 'Starting Promtail...'
 promtail_config='/etc/promtail/config.yaml'
 
+journal_path='/var/log/journal'
+if ! bashio::fs.directory_exists "${journal_path}"; then
+    # Use volatile journal instead
+    journal_path='/run/log/journal'
+fi
+
 case "$(bashio::config 'log_level')" in \
-  error)	log_level='error' ;; \
-  warning)	log_level='warn' ;; \
-  debug)	log_level='debug' ;; \
-  *)		log_level='info' ;; \
+    error)	log_level='error' ;; \
+    warning)	log_level='warn' ;; \
+    debug)	log_level='debug' ;; \
+    *)		log_level='info' ;; \
 esac;
 bashio::log.info "Promtail log level set to ${log_level}"
 
 export "URL=$(bashio::config 'client.url')"
+export "JOURNAL_PATH=${journal_path}"
 export "LOG_LEVEL=$(bashio::config 'log_level')"
 
 promtail_args=("-config.expand-env=true" "-config.file=${promtail_config}")
 if [ "${log_level}" == "debug" ]; then
-  bashio::log.debug "Logging full config on startup for debugging..."
-  promtail_args+=("-print-config-stderr=true")
+    bashio::log.debug "Logging full config on startup for debugging..."
+    promtail_args+=("-print-config-stderr=true")
 fi
 
 bashio::log.info "Handing over control to Promtail..."


### PR DESCRIPTION
Check if `/var/log/journal` exists on startup. If not use the volatile journal at `/run/log/journal`