### PR TITLE
Add directory empty check for 2021.03.9

### DIFF
--- a/promtail/rootfs/etc/services.d/promtail/run
+++ b/promtail/rootfs/etc/services.d/promtail/run
@@ -9,8 +9,8 @@ bashio::log.info 'Starting Promtail...'
 promtail_config='/etc/promtail/config.yaml'
 
 journal_path='/var/log/journal'
-if ! bashio::fs.directory_exists "${journal_path}"; then
-    # Use volatile journal instead
+if ! bashio::fs.directory_exists "${journal_path}" || [ -z "$(ls -A ${journal_path})" ]; then
+    bashio::log.info "No journal at ${journal_path}, looking for journal in /run/log/journal instead"
     journal_path='/run/log/journal'
 fi
 


### PR DESCRIPTION
Starting in supervisor `2021.03.9` both the persistent and volatile journal will be mapped into addons with `journald` set to true (https://github.com/home-assistant/supervisor/pull/2765). Therefore the check for which journal to use has to change to not only look for existence of the directory but ensure it is not empty.