### PR TITLE
Improve traceback handling in HA logs

### DIFF
--- a/promtail/rootfs/etc/promtail/default-scrape-config.yaml
+++ b/promtail/rootfs/etc/promtail/default-scrape-config.yaml
@@ -19,3 +19,9 @@
     - source_labels:
         - __journal_container_name
       target_label: container_name
+  pipeline_stages:
+    - match:
+        selector: '{container_name=~"homeassistant|hassio_supervisor"}'
+        stages:
+          - multiline:
+              firstline: '^\x{001b}'


### PR DESCRIPTION
Add a pipeline stage to the default journal scraping config specifically for HA and Supervisor logs. When each of these applications encounters an exception they dump out the details and then a traceback. 

Currently each line of the traceback appears as an individual log entry which is hard to read. This changes the default config to use a `mulitline` directive on logs from those two specifically to include the traceback and log all as one log entry.