### PR TITLE
Add `additional_pipeline_stages` option

### DIFF
--- a/promtail/DOCS.md
+++ b/promtail/DOCS.md
@@ -82,6 +82,33 @@ The absolute path to the key for the client-authentication certificate if Loki
 is using mTLS to authenticate clients. **Note**: This field is required if
 `client.certfile` is provided
 
+### Option: `additional_pipeline_stages`
+
+The absolute path to a YAML file with a list of additional pipeline stages to
+apply to the [default journal scrape config][addon-default-config]. This file
+must contain only a YAML list of pipeline stages. They will be added to the end
+of the ones already listed. If you don't like what is listed, use `skip_default_scrape_config`
+and `additional_scrape_configs` to write your own instead.
+
+Here's an example of the contents of this file:
+
+```yaml
+- match:
+    selector: '{container_name="addon_cebe7a76_hassio_google_drive_backup"}'
+    stages:
+      - multiline:
+          firstline: '^\x{001b}'
+```
+
+This particular example applies to the [google drive backup addon][addon-google-drive-backup].
+It uses the same log format as Home Assistant and outputs the escape character
+at the start of each log line for color-coding in terminals. Looking for that
+in a multiline stage makes it so tracebacks are included in the same log entry
+as the error that caused them for easier readability.
+
+See the [promtail documenation][promtail-doc-stages] for more information on how
+to configure pipeline stages.
+
 ### Option: `skip_default_scrape_config`
 
 Promtail will scrape the `systemd journal` using a pre-defined config you can
@@ -262,6 +289,7 @@ SOFTWARE.
 [add-repo]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmdegat01%2Fhassio-addons
 [addon-default-config]: https://github.com/mdegat01/addon-promtail/blob/main/promtail/rootfs/etc/promtail/default-scrape-config.yaml
 [addon-grafana]: https://github.com/hassio-addons/addon-grafana
+[addon-google-drive-backup]: https://github.com/sabeechen/hassio-google-drive-backup
 [addon-loki-doc]: https://github.com/mdegat01/addon-loki/blob/main/loki/DOCS.md#grafana
 [addon-z2m]: https://github.com/zigbee2mqtt/hassio-zigbee2mqtt
 [api]: https://grafana.com/docs/loki/latest/clients/promtail/#api
@@ -281,5 +309,6 @@ SOFTWARE.
 [promtail-doc-examples]: https://grafana.com/docs/loki/latest/clients/promtail/configuration/#example-static-config
 [promtil-doc-metrics]: https://grafana.com/docs/loki/latest/clients/promtail/configuration/#metrics
 [promtail-doc-scrape-configs]: https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs
+[promtail-doc-stages]: https://grafana.com/docs/loki/latest/clients/promtail/stages/
 [releases]: https://github.com/mdegat01/addon-promtail/releases
 [semver]: http://semver.org/spec/v2.0.0

--- a/promtail/DOCS.md
+++ b/promtail/DOCS.md
@@ -85,12 +85,14 @@ is using mTLS to authenticate clients. **Note**: This field is required if
 ### Option: `additional_pipeline_stages`
 
 The absolute path to a YAML file with a list of additional pipeline stages to
-apply to the [default journal scrape config][addon-default-config]. This file
-must contain only a YAML list of pipeline stages. They will be added to the end
-of the ones already listed. If you don't like what is listed, use `skip_default_scrape_config`
-and `additional_scrape_configs` to write your own instead.
+apply to the [default journal scrape config][addon-default-config]. The primary
+use of this is to apply additional processing to logs from particular add-ons
+you use if they are noisy or difficult to read.
 
-Here's an example of the contents of this file:
+This file must contain only a YAML list of pipeline stages. They will be added
+to the end of the ones already listed. If you don't like the ones listed, use
+`skip_default_scrape_config` and `additional_scrape_configs` to write your own
+instead. Here's an example of the contents of this file:
 
 ```yaml
 - match:

--- a/promtail/config.json
+++ b/promtail/config.json
@@ -30,6 +30,7 @@
       "certfile": "str?",
       "keyfile": "str?"
     },
+    "additional_pipeline_stages": "str?",
     "additional_scrape_configs": "str?",
     "skip_default_scrape_config": "bool?",
     "log_level": "list(debug|info|warning|error)?"

--- a/promtail/rootfs/etc/cont-init.d/promtail_setup.sh
+++ b/promtail/rootfs/etc/cont-init.d/promtail_setup.sh
@@ -6,6 +6,7 @@
 # ==============================================================================
 config_file=/etc/promtail/config.yaml
 def_scrape_configs=/etc/promtail/default-scrape-config.yaml
+scrape_configs="${def_scrape_configs}"
 
 bashio::log.info 'Setting base config for promtail...'
 cp /etc/promtail/base_config.yaml $config_file
@@ -70,12 +71,38 @@ fi
 } >> $config_file
 if bashio::config.true 'skip_default_scrape_config'; then
     bashio::log.info 'Skipping default journald scrape config...'
+    if bashio::config.exists 'additional_pipeline_stages'; then
+        bashio::log.warning
+        bashio::log.warning "'additional_pipeline_stages' ignored since 'skip_default_scrape_config' is true!"
+        bashio::log.warning 'See documentation for more information.'
+        bashio::log.warning
+    fi
     bashio::config.require 'additional_scrape_configs' "'skip_default_scrape_config' is true"
+
+elif bashio::config.exists'additional_pipeline_stages'; then
+    bashio::log.info "Adding additional pipeline stages to default journal scrape config..."
+    add_stages="$(bashio::config 'additional_pipeline_stages')"
+    scrape_configs=/etc/promtail/journal-scrape-configs.yaml
+    if ! bashio::fs.file_exists "${add_stages}"; then
+        bashio::log.fatal
+        bashio::log.fatal "The file specified for 'additional_pipeline_stages' does not exist!"
+        bashio::log.fatal "Ensure the file exists at the path specified"
+        bashio::log.fatal
+        bashio::exit.nok
+    fi
+
+    yq -NP eval-all \
+        'select(fi == 0) + [{"add_pipeline_stages": select(fi == 1)}]' \
+        $def_scrape_configs "${add_stages}" \
+    | yq -NP e \
+        '[(.[0] * .[1]) | {"job_name": .job_name, "journal": .journal, "relabel_configs": .relabel_configs, "pipeline_stages": .pipeline_stages + .add_pipeline_stages}]' \
+        - > $scrape_configs
 fi
 
 if bashio::config.exists 'additional_scrape_configs'; then
     bashio::log.info "Adding custom scrape configs..."
-    if ! bashio::fs.file_exists "$(bashio::config 'additional_scrape_configs')"; then
+    add_scrape_configs="$(bashio::config 'additional_scrape_configs')"
+    if ! bashio::fs.file_exists "${add_scrape_configs}"; then
         bashio::log.fatal
         bashio::log.fatal "The file specified for 'additional_scrape_configs' does not exist!"
         bashio::log.fatal "Ensure the file exists at the path specified"
@@ -83,13 +110,12 @@ if bashio::config.exists 'additional_scrape_configs'; then
         bashio::exit.nok
     fi
 
-    add_scrape_configs="$(bashio::config 'additional_scrape_configs')"
     if bashio::config.true 'skip_default_scrape_config'; then
         yq -NP e '[] + .' "$add_scrape_configs" >> $config_file
     else
-        yq -NP eval-all 'select(fi == 0) * select(fi == 1)' \
-            $def_scrape_configs "$add_scrape_configs" >> $config_file
+        yq -NP eval-all 'select(fi == 0) + select(fi == 1)' \
+            $scrape_configs "$add_scrape_configs" >> $config_file
     fi
 else
-    yq -NP e '[] + .' $def_scrape_configs >> $config_file
+    yq -NP e '[] + .' $scrape_configs >> $config_file
 fi


### PR DESCRIPTION
Added an option to allow people to specify additional pipeline stages to apply to the journal config. This allows people to apply additional processing to journal logs coming from particular addons they use since every addon uses different logging formats.