### PR TITLE
Revert "Run as non-root user"

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -52,9 +52,7 @@ RUN set -eux; \
 
 COPY rootfs /
 RUN set -eux; \
-    mkdir -p /data/promtail; \
-    useradd -u 12345 -U -d /data/promtail/ -s /bin/false promtail; \
-    usermod -G users promtail;
+    mkdir -p /data/promtail;
 WORKDIR /data/promtail
 
 # Build arguments

--- a/promtail/rootfs/etc/cont-init.d/promtail_setup.sh
+++ b/promtail/rootfs/etc/cont-init.d/promtail_setup.sh
@@ -119,6 +119,3 @@ if bashio::config.exists 'additional_scrape_configs'; then
 else
     yq -NP e '[] + .' "${scrape_configs}" >> "${config_file}"
 fi
-
-# permissions
-chown -R promtail:promtail /data/promtail

--- a/promtail/rootfs/etc/services.d/promtail/run
+++ b/promtail/rootfs/etc/services.d/promtail/run
@@ -33,4 +33,4 @@ if [ "${log_level}" == "debug" ]; then
 fi
 
 bashio::log.info "Handing over control to Promtail..."
-exec s6-setuidgid promtail promtail "${promtail_args[@]}"
+promtail "${promtail_args[@]}"


### PR DESCRIPTION
Reverts mdegat01/addon-promtail#21

Non-root user can't access the journal. And its mapped and shared with new files added regularly. This won't work.