### PR TITLE
Add armhf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ SOFTWARE.
 [add-repo-shield]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
 [add-repo]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmdegat01%2Fhassio-addons
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
+[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/mdegat01/addon-promtail.svg
 [commits]: https://github.com/mdegat01/addon-promtail/commits/main

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,10 +1,34 @@
 # https://github.com/hassio-addons/addon-debian-base/releases
 ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:4.1.3
 
-FROM golang:1.16.2-buster as build
+# yq is used to merge YAML files
+# https://github.com/mikefarah/yq/releases
+FROM alpine:3.13.4 as build_yq
+ARG BUILD_ARCH=amd64
+ENV YQ_VERSION 4.6.1
+
+RUN set -eux; \
+    apk update; \
+    apk add --no-cache --virtual .build-deps \
+        tar=1.33-r1 \
+        curl=7.74.0-r1 \
+        ; \
+    case "$BUILD_ARCH" in \
+        amd64)  BINARCH='amd64' ;; \
+        armhf)   BINARCH='arm' ;; \
+        armv7)   BINARCH='arm' ;; \
+        aarch64) BINARCH='arm64' ;; \
+        *) echo >&2 "error: unsupported architecture ($BUILD_ARCH)"; exit 1 ;; \
+    esac; \
+    curl -J -L -o /tmp/yq.tar.gz "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${BINARCH}.tar.gz"; \
+    tar -xf /tmp/yq.tar.gz -C /usr/bin; \
+    mv /usr/bin/yq_linux_${BINARCH} /usr/bin/yq;
+
 
 # https://github.com/grafana/loki/releases
+FROM golang:1.16.2-buster as build_loki
 ENV LOKI_VERSION 2.2.0
+WORKDIR /src
 
 # Must build binary from source on system with journal support. Published binaries on release do not include this.
 RUN set -eux; \
@@ -15,19 +39,14 @@ RUN set -eux; \
         libsystemd-dev=247.3-3~bpo10+1 \
         ; \
     curl -J -L -o /tmp/loki.tar.gz "https://github.com/grafana/loki/archive/refs/tags/v${LOKI_VERSION}.tar.gz"; \
-    mkdir -p /src; \
     tar -xf /tmp/loki.tar.gz -C /src; \
-    mv "/src/loki-${LOKI_VERSION}" /src/loki;
+    mv "/src/loki-${LOKI_VERSION}" /src/loki; \
+    cd /src/loki; \
+    make BUILD_IN_CONTAINER=false promtail;
 
-WORKDIR /src/loki
-RUN make BUILD_IN_CONTAINER=false promtail
 
 # hadolint ignore=DL3006
 FROM $BUILD_FROM
-ARG BUILD_ARCH=amd64
-
-# Add promtail
-COPY --from=build /src/loki/cmd/promtail/promtail /usr/bin/promtail
 
 # tzdata required for the timestamp stage to work
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
@@ -46,31 +65,16 @@ RUN set -eux; \
     promtail --version; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*;
 
-# yq is used to merge YAML files
-# https://github.com/mikefarah/yq/releases
-ENV YQ_VERSION 4.6.1
 
-# Add yq (and its dependency, jq)
+# Add promtail & yq
+COPY --from=build_loki /src/loki/cmd/promtail/promtail /usr/bin/promtail
+COPY --from=build_yq /usr/bin/yq /usr/bin/yq
 RUN set -eux; \
-    apt-get install -qy --no-install-recommends \
-        jq=1.5+dfsg-2+b1 \
-        ; \
-    case "$BUILD_ARCH" in \
-        amd64)  BINARCH='amd64' ;; \
-        armhf)   BINARCH='arm' ;; \
-        armv7)   BINARCH='arm' ;; \
-        aarch64) BINARCH='arm64' ;; \
-        *) echo >&2 "error: unsupported architecture ($BUILD_ARCH)"; exit 1 ;;\
-    esac; \
-    curl -J -L -o /tmp/yq.tar.gz "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${BINARCH}.tar.gz"; \
-    tar -xf /tmp/yq.tar.gz -C /usr/bin; \
-    mv /usr/bin/yq_linux_${BINARCH} /usr/bin/yq; \
     chmod a+x /usr/bin/yq; \
-    rm -rf /tmp/*;
+    yq --version; \
+    promtail --version;
 
 COPY rootfs /
-RUN set -eux; \
-    mkdir -p /data/promtail;
 WORKDIR /data/promtail
 
 # Build arguments

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
         libsystemd-dev=247.3-3~bpo10+1 \
         ; \
     curl -J -L -o /tmp/loki.tar.gz "https://github.com/grafana/loki/archive/refs/tags/v${LOKI_VERSION}.tar.gz"; \
+    mkdir -p /src; \
     tar -xf /tmp/loki.tar.gz -C /src; \
     mv "/src/loki-${LOKI_VERSION}" /src/loki;
 

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,13 +1,32 @@
 # https://github.com/hassio-addons/addon-debian-base/releases
 ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:4.1.3
 
-# https://hub.docker.com/r/grafana/promtail
+FROM golang:1.16.2-buster as build
+
 # https://github.com/grafana/loki/releases
-FROM grafana/promtail:2.2.0 as build
+ENV LOKI_VERSION 2.2.0
+
+# Must build binary from source on system with journal support. Published binaries on release do not include this.
+RUN set -eux; \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list; \
+    apt-get update; \
+    apt-get install -qy --no-install-recommends \ 
+        -t buster-backports \
+        libsystemd-dev=247.3-3~bpo10+1 \
+        ; \
+    curl -J -L -o /tmp/loki.tar.gz "https://github.com/grafana/loki/archive/refs/tags/v${LOKI_VERSION}.tar.gz"; \
+    tar -xf /tmp/loki.tar.gz -C /src; \
+    mv "/src/loki-${LOKI_VERSION}" /src/loki;
+
+WORKDIR /src/loki
+RUN make BUILD_IN_CONTAINER=false promtail
 
 # hadolint ignore=DL3006
 FROM $BUILD_FROM
 ARG BUILD_ARCH=amd64
+
+# Add promtail
+COPY --from=build /src/loki/cmd/promtail/promtail /usr/bin/promtail
 
 # tzdata required for the timestamp stage to work
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
@@ -23,10 +42,8 @@ RUN set -eux; \
         libsystemd-dev=247.3-3~bpo10+1 \
         ; \
     update-ca-certificates; \
+    promtail --version; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*;
-
-# Add promtail
-COPY --from=build /usr/bin/promtail /usr/bin/promtail
 
 # yq is used to merge YAML files
 # https://github.com/mikefarah/yq/releases

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -22,13 +22,13 @@ RUN set -eux; \
     esac; \
     curl -J -L -o /tmp/yq.tar.gz "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${BINARCH}.tar.gz"; \
     tar -xf /tmp/yq.tar.gz -C /usr/bin; \
-    mv /usr/bin/yq_linux_${BINARCH} /usr/bin/yq;
+    mv /usr/bin/yq_linux_${BINARCH} /usr/bin/yq; \
+    chmod a+x /usr/bin/yq;
 
 
 # https://github.com/grafana/loki/releases
 FROM golang:1.16.2-buster as build_loki
 ENV LOKI_VERSION 2.2.0
-WORKDIR /src
 
 # Must build binary from source on system with journal support. Published binaries on release do not include this.
 RUN set -eux; \
@@ -39,10 +39,12 @@ RUN set -eux; \
         libsystemd-dev=247.3-3~bpo10+1 \
         ; \
     curl -J -L -o /tmp/loki.tar.gz "https://github.com/grafana/loki/archive/refs/tags/v${LOKI_VERSION}.tar.gz"; \
+    mkdir -p /src; \
     tar -xf /tmp/loki.tar.gz -C /src; \
-    mv "/src/loki-${LOKI_VERSION}" /src/loki; \
-    cd /src/loki; \
-    make BUILD_IN_CONTAINER=false promtail;
+    mv "/src/loki-${LOKI_VERSION}" /src/loki;
+
+WORKDIR /src/loki
+RUN make BUILD_IN_CONTAINER=false promtail
 
 
 # hadolint ignore=DL3006
@@ -62,7 +64,6 @@ RUN set -eux; \
         libsystemd-dev=247.3-3~bpo10+1 \
         ; \
     update-ca-certificates; \
-    promtail --version; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*;
 
 
@@ -70,7 +71,6 @@ RUN set -eux; \
 COPY --from=build_loki /src/loki/cmd/promtail/promtail /usr/bin/promtail
 COPY --from=build_yq /usr/bin/yq /usr/bin/yq
 RUN set -eux; \
-    chmod a+x /usr/bin/yq; \
     yq --version; \
     promtail --version;
 

--- a/promtail/build.json
+++ b/promtail/build.json
@@ -1,6 +1,7 @@
 {
   "build_from": {
     "amd64": "ghcr.io/hassio-addons/debian-base/amd64:4.1.3",
+    "armhf": "ghcr.io/hassio-addons/debian-base/armhf:4.1.3",
     "armv7": "ghcr.io/hassio-addons/debian-base/armv7:4.1.3",
     "aarch64": "ghcr.io/hassio-addons/debian-base/aarch64:4.1.3"
   }

--- a/promtail/config.json
+++ b/promtail/config.json
@@ -3,7 +3,7 @@
   "url": "https://github.com/mdegat01/addon-promtail",
   "version": "edge",
   "slug": "promtail",
-  "arch": ["aarch64", "amd64", "armv7"],
+  "arch": ["aarch64", "amd64", "armv7", "armhf"],
   "description": "Promtail for Home Assistant",
   "journald": true,
   "map": ["share", "ssl"],


### PR DESCRIPTION
Add support for `armhf` as I believe Promtail does based on the binaries it publishes and reading in the repo. I don't have this type of machine available though so not any good way to test it.