### PR TITLE
Pull Promtail binary from published images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,14 +147,19 @@ jobs:
           echo "::set-output name=from::${from}"
           if [[ "${{ matrix.architecture}}" = "amd64" ]]; then
             echo "::set-output name=platform::linux/amd64"
+            echo "::set-output name=image_arch::amd64"
           elif [[ "${{ matrix.architecture }}" = "i386" ]]; then
             echo "::set-output name=platform::linux/386"
+            echo "::set-output name=image_arch::386"
           elif [[ "${{ matrix.architecture }}" = "armhf" ]]; then
             echo "::set-output name=platform::linux/arm/v6"
+            echo "::set-output name=image_arch::arm"
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
             echo "::set-output name=platform::linux/arm/v7"
+            echo "::set-output name=image_arch::arm"
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
             echo "::set-output name=platform::linux/arm64/v8"
+            echo "::set-output name=image_arch::arm64"
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1
@@ -179,3 +184,4 @@ jobs:
             BUILD_REF=${{ github.sha }}
             BUILD_REPOSITORY=${{ github.repository }}
             BUILD_VERSION=edge
+            BUILD_IMAGE_ARCH=${{ steps.flags.outputs.image_arch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,19 +147,15 @@ jobs:
           echo "::set-output name=from::${from}"
           if [[ "${{ matrix.architecture}}" = "amd64" ]]; then
             echo "::set-output name=platform::linux/amd64"
-            echo "::set-output name=image_arch::amd64"
           elif [[ "${{ matrix.architecture }}" = "i386" ]]; then
             echo "::set-output name=platform::linux/386"
-            echo "::set-output name=image_arch::386"
           elif [[ "${{ matrix.architecture }}" = "armhf" ]]; then
             echo "::set-output name=platform::linux/arm/v6"
-            echo "::set-output name=image_arch::arm"
+            echo "::set-output name=image_arch::-arm"
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
             echo "::set-output name=platform::linux/arm/v7"
-            echo "::set-output name=image_arch::arm"
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
             echo "::set-output name=platform::linux/arm64/v8"
-            echo "::set-output name=image_arch::arm64"
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -84,14 +84,19 @@ jobs:
           echo "::set-output name=from::${from}"
           if [[ "${{ matrix.architecture}}" = "amd64" ]]; then
             echo "::set-output name=platform::linux/amd64"
+            echo "::set-output name=image_arch::amd64"
           elif [[ "${{ matrix.architecture }}" = "i386" ]]; then
             echo "::set-output name=platform::linux/386"
+            echo "::set-output name=image_arch::386"
           elif [[ "${{ matrix.architecture }}" = "armhf" ]]; then
             echo "::set-output name=platform::linux/arm/v6"
+            echo "::set-output name=image_arch::arm"
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
             echo "::set-output name=platform::linux/arm/v7"
+            echo "::set-output name=image_arch::arm"
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
             echo "::set-output name=platform::linux/arm64/v8"
+            echo "::set-output name=image_arch::arm64"
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1
@@ -127,6 +132,7 @@ jobs:
             BUILD_REF=${{ github.sha }}
             BUILD_REPOSITORY=${{ github.repository }}
             BUILD_VERSION=${{ needs.information.outputs.version }}
+            BUILD_IMAGE_ARCH=${{ steps.flags.outputs.image_arch }}
   publish-edge:
     name: 📢 Publish to edge repository
     if: needs.information.outputs.environment == 'edge'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -84,19 +84,15 @@ jobs:
           echo "::set-output name=from::${from}"
           if [[ "${{ matrix.architecture}}" = "amd64" ]]; then
             echo "::set-output name=platform::linux/amd64"
-            echo "::set-output name=image_arch::amd64"
           elif [[ "${{ matrix.architecture }}" = "i386" ]]; then
             echo "::set-output name=platform::linux/386"
-            echo "::set-output name=image_arch::386"
           elif [[ "${{ matrix.architecture }}" = "armhf" ]]; then
             echo "::set-output name=platform::linux/arm/v6"
-            echo "::set-output name=image_arch::arm"
+            echo "::set-output name=image_arch::-arm"
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
             echo "::set-output name=platform::linux/arm/v7"
-            echo "::set-output name=image_arch::arm"
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
             echo "::set-output name=platform::linux/arm64/v8"
-            echo "::set-output name=image_arch::arm64"
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,18 +1,17 @@
 # https://github.com/hassio-addons/addon-debian-base/releases
 ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:4.1.3
 
-# Grafana builds promtail images for amd64, arm and arm64 with journal support
-# Binary can be pulled from them for each arch we support but need a mapping
-# Won't just work since they don't tag any with `linux/arm/v6` (i.e. `armhf`)
-# amd64 -> amd64, armv7 & armhf -> arm, aarch64 -> arm64
+# Grafana build Promtail images for amd64, armv7 and aarch64 with journal support
+# They also make a separate arm image we can use for armhf but with difficulty
+# Conditionally setting a postfix for image location only for armhf
 # Note: build.json can't really do this, workflows modified to set this arg
-ARG BUILD_IMAGE_ARCH=amd64
+ARG BUILD_IMAGE_ARCH=
 
 # https://github.com/grafana/loki/releases
 ARG PROMTAIL_VERSION=2.2.0
 
 # https://hub.docker.com/r/grafana/promtail
-FROM grafana/promtail:${PROMTAIL_VERSION}-${BUILD_IMAGE_ARCH} as build
+FROM grafana/promtail:${PROMTAIL_VERSION}${BUILD_IMAGE_ARCH} as build
 
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
@@ -44,7 +43,6 @@ RUN yq --version
 # Add promtail
 COPY --from=build /usr/bin/promtail /usr/bin/promtail
 # See https://github.com/grafana/loki/blob/v2.2.0/cmd/promtail/Dockerfile.arm32#L21
-ARG BUILD_IMAGE_ARCH=amd64
 RUN if [[ ${BUILD_ARCH} =~ armv7|armhf ]] && [ ! -f /lib/ld-linux-armhf.so.3 ]; then \
         echo 'RE-LINKING LD-LINUX-ARMHF.SO.3' \
         && ln -s /lib/ld-linux.so.3 /lib/ld-linux-armhf.so.3; \

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -44,10 +44,8 @@ RUN yq --version
 # Add promtail
 COPY --from=build /usr/bin/promtail /usr/bin/promtail
 # See https://github.com/grafana/loki/blob/v2.2.0/cmd/promtail/Dockerfile.arm32#L21
-RUN [[ ${BUILD_ARCH} =~ armv7|armhf ]] \
-    && [ ! -f /lib/ld-linux-armhf.so.3 ] \
-    && echo RE-LINKING LD-LINUX-ARMHF.SO.3 \
-    && ln -s /lib/ld-linux.so.3 /lib/ld-linux-armhf.so.3
+ARG BUILD_IMAGE_ARCH=amd64
+RUN sh -c '[ ${BUILD_IMAGE_ARCH} = arm ] && [ ! -f /lib/ld-linux-armhf.so.3 ] && echo RE-LINKING LD-LINUX-ARMHF.SO.3 && ln -s /lib/ld-linux.so.3 /lib/ld-linux-armhf.so.3'
 RUN promtail --version
 
 COPY rootfs /

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -40,6 +40,12 @@ RUN yq --version
 
 # Add promtail
 COPY --from=build /usr/bin/promtail /usr/bin/promtail
+# See https://github.com/grafana/loki/blob/v2.2.0/cmd/promtail/Dockerfile.arm32#L21
+ARG BUILD_IMAGE_ARCH=amd64
+RUN [ ${BUILD_IMAGE_ARCH} = "arm" ] \
+    && [ ! -f /lib/ld-linux-armhf.so.3 ] \
+    && echo RE-LINKING LD-LINUX-ARMHF.SO.3 \
+    && ln -s /lib/ld-linux.so.3 /lib/ld-linux-armhf.so.3
 RUN promtail --version
 
 COPY rootfs /

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -17,6 +17,9 @@ FROM grafana/promtail:${PROMTAIL_VERSION}-${BUILD_IMAGE_ARCH} as build
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
+# Set shell
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # tzdata required for the timestamp stage to work
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
 RUN set -eux; \
@@ -41,8 +44,7 @@ RUN yq --version
 # Add promtail
 COPY --from=build /usr/bin/promtail /usr/bin/promtail
 # See https://github.com/grafana/loki/blob/v2.2.0/cmd/promtail/Dockerfile.arm32#L21
-ARG BUILD_IMAGE_ARCH=amd64
-RUN [ ${BUILD_IMAGE_ARCH} = "arm" ] \
+RUN [[ ${BUILD_ARCH} =~ armv7|armhf ]] \
     && [ ! -f /lib/ld-linux-armhf.so.3 ] \
     && echo RE-LINKING LD-LINUX-ARMHF.SO.3 \
     && ln -s /lib/ld-linux.so.3 /lib/ld-linux-armhf.so.3

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -43,7 +43,7 @@ RUN yq --version
 # Add promtail
 COPY --from=build /usr/bin/promtail /usr/bin/promtail
 # See https://github.com/grafana/loki/blob/v2.2.0/cmd/promtail/Dockerfile.arm32#L21
-RUN if [[ ${BUILD_ARCH} =~ armv7|armhf ]] && [ ! -f /lib/ld-linux-armhf.so.3 ]; then \
+RUN if [[ ${BUILD_ARCH} == armhf ]] && [ ! -f /lib/ld-linux-armhf.so.3 ]; then \
         echo 'RE-LINKING LD-LINUX-ARMHF.SO.3' \
         && ln -s /lib/ld-linux.so.3 /lib/ld-linux-armhf.so.3; \
     fi

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,29 +1,21 @@
 # https://github.com/hassio-addons/addon-debian-base/releases
 ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:4.1.3
 
+# Grafana builds promtail images for amd64, arm and arm64 with journal support
+# Binary can be pulled from them for each arch we support but need a mapping
+# Won't just work since they don't tag any with `linux/arm/v6` (i.e. `armhf`)
+# amd64 -> amd64, armv7 & armhf -> arm, aarch64 -> arm64
+# Note: build.json can't really do this, workflows modified to set this arg
+ARG BUILD_IMAGE_ARCH=amd64
+
 # https://github.com/grafana/loki/releases
-FROM golang:1.16.2-buster as build_loki
-ENV LOKI_VERSION 2.2.0
+ARG PROMTAIL_VERSION=2.2.0
 
-# Must build binary from source on system with journal support. Published binaries on release do not include this.
-RUN set -eux; \
-    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list; \
-    apt-get update; \
-    apt-get install -qy --no-install-recommends \ 
-        -t buster-backports \
-        libsystemd-dev=247.3-3~bpo10+1 \
-        ; \
-    curl -J -L -o /tmp/loki.tar.gz "https://github.com/grafana/loki/archive/refs/tags/v${LOKI_VERSION}.tar.gz"; \
-    mkdir -p /src; \
-    tar -xf /tmp/loki.tar.gz -C /src; \
-    mv "/src/loki-${LOKI_VERSION}" /src/loki;
-
-WORKDIR /src/loki
-RUN make BUILD_IN_CONTAINER=false promtail
-
+# https://hub.docker.com/r/grafana/promtail
+FROM grafana/promtail:${PROMTAIL_VERSION}-${BUILD_IMAGE_ARCH} as build
 
 # hadolint ignore=DL3006
-FROM $BUILD_FROM
+FROM ${BUILD_FROM}
 
 # tzdata required for the timestamp stage to work
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
@@ -47,7 +39,7 @@ COPY bin/yq_linux_${BUILD_ARCH} /usr/bin/yq
 RUN yq --version
 
 # Add promtail
-COPY --from=build_loki /src/loki/cmd/promtail/promtail /usr/bin/promtail
+COPY --from=build /usr/bin/promtail /usr/bin/promtail
 RUN promtail --version
 
 COPY rootfs /

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -45,7 +45,10 @@ RUN yq --version
 COPY --from=build /usr/bin/promtail /usr/bin/promtail
 # See https://github.com/grafana/loki/blob/v2.2.0/cmd/promtail/Dockerfile.arm32#L21
 ARG BUILD_IMAGE_ARCH=amd64
-RUN sh -c '[ ${BUILD_IMAGE_ARCH} = arm ] && [ ! -f /lib/ld-linux-armhf.so.3 ] && echo RE-LINKING LD-LINUX-ARMHF.SO.3 && ln -s /lib/ld-linux.so.3 /lib/ld-linux-armhf.so.3'
+RUN if [[ ${BUILD_ARCH} =~ armv7|armhf ]] && [ ! -f /lib/ld-linux-armhf.so.3 ]; then \
+        echo 'RE-LINKING LD-LINUX-ARMHF.SO.3' \
+        && ln -s /lib/ld-linux.so.3 /lib/ld-linux-armhf.so.3; \
+    fi
 RUN promtail --version
 
 COPY rootfs /

--- a/promtail/build.json
+++ b/promtail/build.json
@@ -4,5 +4,8 @@
     "armhf": "ghcr.io/hassio-addons/debian-base/armhf:4.1.3",
     "armv7": "ghcr.io/hassio-addons/debian-base/armv7:4.1.3",
     "aarch64": "ghcr.io/hassio-addons/debian-base/aarch64:4.1.3"
+  },
+  "args": {
+    "PROMTAIL_VERSION": "2.2.0"
   }
 }


### PR DESCRIPTION
Modified workflows to set a new arg `BUILD_IMAGE_ARCH`. This is mapped from architecture like build from and allows me to pull the corresponding published image for the architecture from DockerHub, even though none are explicitly tagged with `linux/arm/v6`. Mapping is as follows:

1. `amd64` (unchanged)
2. `armv7` & `armhf` -> `arm`
3. `aarch64` -> `arm64`

Since we're no longer making binaries as part of the Dockerfile, should hopefully speed up the build process.