### PR TITLE
Update to Promtail 2.2.1 and use pre-built binary

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,26 +1,12 @@
 # https://github.com/hassio-addons/addon-debian-base/releases
 ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:4.1.3
+ARG BUILD_ARCH=amd64
+
+# https://github.com/mdegat01/promtail-journal/releases
+ARG PROMTAIL_BASE_VERSION=1.0.0
 
 # https://github.com/grafana/loki/releases
-FROM golang:1.16.2-buster as build_loki
-ENV LOKI_VERSION 2.2.0
-
-# Must build binary from source on system with journal support. Published binaries on release do not include this.
-RUN set -eux; \
-    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list; \
-    apt-get update; \
-    apt-get install -qy --no-install-recommends \ 
-        -t buster-backports \
-        libsystemd-dev=247.3-3~bpo10+1 \
-        ; \
-    curl -J -L -o /tmp/loki.tar.gz "https://github.com/grafana/loki/archive/refs/tags/v${LOKI_VERSION}.tar.gz"; \
-    mkdir -p /src; \
-    tar -xf /tmp/loki.tar.gz -C /src; \
-    mv "/src/loki-${LOKI_VERSION}" /src/loki;
-
-WORKDIR /src/loki
-RUN make BUILD_IN_CONTAINER=false promtail
-
+FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:${PROMTAIL_BASE_VERSION} as build
 
 # hadolint ignore=DL3006
 FROM $BUILD_FROM
@@ -47,7 +33,7 @@ COPY bin/yq_linux_${BUILD_ARCH} /usr/bin/yq
 RUN yq --version
 
 # Add promtail
-COPY --from=build_loki /src/loki/cmd/promtail/promtail /usr/bin/promtail
+COPY --from=build /usr/bin/promtail /usr/bin/promtail
 RUN promtail --version
 
 COPY rootfs /

--- a/promtail/build.json
+++ b/promtail/build.json
@@ -4,5 +4,8 @@
     "armhf": "ghcr.io/hassio-addons/debian-base/armhf:4.1.3",
     "armv7": "ghcr.io/hassio-addons/debian-base/armv7:4.1.3",
     "aarch64": "ghcr.io/hassio-addons/debian-base/aarch64:4.1.3"
+  },
+  "args": {
+    "PROMTAIL_BASE_VERSION": "1.0.0"
   }
 }


### PR DESCRIPTION
Building Promtail binary in a [separate repo](https://github.com/mdegat01/promtail-journal) since it takes forever. This way the addon can build faster as it is more frequently updated, other will only update when Promtail does.

Additionally, Grafana released 2.2.1 of Promtail and Loki so update to that as well.