### PR TITLE
Support all log levels

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -13,7 +13,7 @@ ENV YQ_VERSION 4.6.3
 RUN set -eux; \
     apk update; \
     apk add --no-cache --virtual .build-deps \
-        tar=1.33-r1 \
+        tar=1.34-r0 \
         curl=7.74.0-r1 \
     ; \
     APKARCH="$(apk --print-arch)"; \

--- a/promtail/config.json
+++ b/promtail/config.json
@@ -33,6 +33,6 @@
     "additional_pipeline_stages": "str?",
     "additional_scrape_configs": "str?",
     "skip_default_scrape_config": "bool?",
-    "log_level": "list(debug|info|warning|error)?"
+    "log_level": "list(trace|debug|info|notice|warning|error|fatal)?"
   }
 }

--- a/promtail/rootfs/etc/services.d/promtail/run
+++ b/promtail/rootfs/etc/services.d/promtail/run
@@ -15,10 +15,13 @@ if ! bashio::fs.directory_exists "${journal_path}" || [ -z "$(ls -A ${journal_pa
 fi
 
 case "$(bashio::config 'log_level')" in \
-    error)	    log_level='error' ;; \
-    warning)	log_level='warn' ;; \
-    debug)	    log_level='debug' ;; \
-    *)		    log_level='info' ;; \
+    trace)      ;& \
+    debug)      log_level='debug' ;; \
+    notice)     ;& \
+    warning)    log_level='warn' ;; \
+    error)      ;& \
+    fatal)      log_level='error' ;; \
+    *)          log_level='info' ;; \
 esac;
 bashio::log.info "Promtail log level set to ${log_level}"
 


### PR DESCRIPTION
Support all log level options. Map any that Promtail doesn't support to the logical option that it does.

Also update tar to latest so we can build (`1.34-r0`)