### PR TITLE
Allow read from anywhere in `/data`

### DIFF
--- a/promtail/apparmor.txt
+++ b/promtail/apparmor.txt
@@ -58,6 +58,7 @@ profile promtail flags=(attach_disconnected,mediate_deleted) {
     /usr/bin/** rix,
 
     # Addon data
+    /data/** r,
     /data/promtail/** rw,
 
     # Log sources


### PR DESCRIPTION
Small tweak to apparmor profile, allow application to read from anywhere in `/data`. It still only writes to `/data/promtail` though.