### PR TITLE
Limit network access to promtail in apparmor

### DIFF
--- a/promtail/apparmor.txt
+++ b/promtail/apparmor.txt
@@ -6,9 +6,6 @@ profile promtail flags=(attach_disconnected,mediate_deleted) {
   # Send signals to children
   signal (send) set=(kill,term,int,hup,cont),
 
-  # Send & receive tcp traffic
-  network tcp,
-
   # S6-Overlay
   /init rix,
   /bin/** rix,


### PR DESCRIPTION
S6 doesn't need network access, only Promtail does. Remove `network tcp` at the base level.