### PR TITLE
Wrong character on apparmor variable

### DIFF
--- a/promtail/apparmor.txt
+++ b/promtail/apparmor.txt
@@ -46,7 +46,7 @@ profile promtail flags=(attach_disconnected,mediate_deleted) {
     
     # Receive signals from S6-Overlay & ourselves
     signal receive,
-    signal peer=${profile_name},
+    signal peer=@{profile_name},
 
     # Send & receive tcp traffic
     network tcp,


### PR DESCRIPTION
Using the wrong character for a variable in apparmor profile to do self-signal