### PR TITLE
Deprecate absolute path support for cafile & support blanking out

### DIFF
--- a/promtail/DOCS.md
+++ b/promtail/DOCS.md
@@ -62,8 +62,10 @@ provided.
 
 ### Option: `client.cafile`
 
-The absolute path to the CA certificate used to sign Loki's certificate if Loki
-is using a self-signed certificate for SSL.
+The CA certificate used to sign Loki's certificate if Loki is using a self-signed
+certificate for SSL.
+
+**Note**: _The file MUST be stored in `/ssl/`, which is the default_
 
 ### Option: `client.servername`
 

--- a/promtail/rootfs/etc/cont-init.d/promtail_setup.sh
+++ b/promtail/rootfs/etc/cont-init.d/promtail_setup.sh
@@ -22,9 +22,21 @@ if bashio::config.exists 'client.username'; then
     } >> "${config_file}"
 fi
 
-if bashio::config.exists 'client.cafile'; then
+if ! bashio::config.is_empty 'client.cafile'; then
     bashio::log.info "Adding TLS to client config..."
-    if ! bashio::fs.file_exists "$(bashio::config 'client.cafile')"; then
+    cafile=$(bashio::config 'cafile')
+
+    # Absolute path support deprecated 4/21 for release 1.5.0.
+    # Wait until at least 5/21 to remove
+    if [[ $cafile =~ ^\/ ]]; then
+        bashio::log.warning "Providing an absolute path for 'client.cafile' is deprecated."
+        bashio::log.warning "Support for absolute paths will be removed in a future release."
+        bashio::log.warning "Please put your CA file in /ssl and provide a relative path."
+    else
+        cafile="/ssl/${cafile}"
+    fi
+
+    if ! bashio::fs.file_exists "${cafile}"; then
         bashio::log.fatal
         bashio::log.fatal "The file specified for 'cafile' does not exist!"
         bashio::log.fatal "Ensure the CA certificate file exists and full path is provided"
@@ -33,7 +45,7 @@ if bashio::config.exists 'client.cafile'; then
     fi
     {
         echo "    tls_config:"
-        echo "      ca_file: $(bashio::config 'client.cafile')"
+        echo "      ca_file: ${cafile}"
     } >> "${config_file}"
 
     if bashio::config.exists 'client.servername'; then

--- a/promtail/rootfs/etc/cont-init.d/promtail_setup.sh
+++ b/promtail/rootfs/etc/cont-init.d/promtail_setup.sh
@@ -26,7 +26,7 @@ if ! bashio::config.is_empty 'client.cafile'; then
     bashio::log.info "Adding TLS to client config..."
     cafile=$(bashio::config 'cafile')
 
-    # Absolute path support deprecated 4/21 for release 1.5.0.
+    # Absolute path support deprecated 4/21 for release 1.4.1.
     # Wait until at least 5/21 to remove
     if [[ $cafile =~ ^\/ ]]; then
         bashio::log.warning "Providing an absolute path for 'client.cafile' is deprecated."


### PR DESCRIPTION
Based on other addons, correct approach is to be opinionated about where files should be. Therefore deprecating the ability to provide an absolute path for `client.cafile` and requiring it be in `/ssl`. Using an absolute path only gives a warning for now, will remove in a future release (sometime May 2021 or later).

Also switch check on `client.cafile` option to `is_empty` instead of `exists`. This works better with the UI-based config since it won't let you remove string-type config options, only blank them out.