### PR TITLE
Used loki's config option not promtails

### DIFF
--- a/promtail/rootfs/etc/cont-init.d/promtail_setup.sh
+++ b/promtail/rootfs/etc/cont-init.d/promtail_setup.sh
@@ -24,7 +24,7 @@ fi
 
 if ! bashio::config.is_empty 'client.cafile'; then
     bashio::log.info "Adding TLS to client config..."
-    cafile=$(bashio::config 'cafile')
+    cafile=$(bashio::config 'client.cafile')
 
     # Absolute path support deprecated 4/21 for release 1.4.1.
     # Wait until at least 5/21 to remove


### PR DESCRIPTION
Last change accidently used loki's config for `cafile` instead of promtails (`client.cafile`)