### PR TITLE
Remove supervisor version warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ to every machine that has applications needed to be monitored.
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
 [![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
 
-⚠ This addon requires supervisor version `2021.03.8` as it relies on the new
-`journald` capability just added. This is the current beta release as of 3/26.
-If you don't want to join the beta channel, you can wait until it becomes the
-stable release in a couple days.
-
 ## About
 
 By default this addon version of Promtail will tail logs from the systemd

--- a/promtail/.README.j2
+++ b/promtail/.README.j2
@@ -11,11 +11,6 @@
 [Loki][loki] instance or [Grafana Cloud][grafana-cloud]. It is usually deployed
 to every machine that has applications needed to be monitored.
 
-⚠ This addon requires supervisor version `2021.03.8` as it relies on the new
-`journald` capability just added. This is the current beta release as of 3/26.
-If you don't want to join the beta channel, you can wait until it becomes the
-stable release in a couple days.
-
 {% set repository = namespace(url='https%3A//github.com/mdegat01/hassio-addons', slug='39bd2704') %}
 {% if channel == "edge" %}
 {% set repository.url = repository.url + '-edge' %}


### PR DESCRIPTION
Remove warning about supervisor version as the journald feature is now in stable and we're already on the next version after that.