### PR TITLE
Use the `do_usr` variable

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux; \
     apk update; \
     apk add --no-cache --virtual .build-deps \
         tar=1.34-r0 \
-        curl=7.74.0-r1 \
+        curl=7.76.1-r0 \
     ; \
     APKARCH="$(apk --print-arch)"; \
     case "${APKARCH}" in \

--- a/promtail/apparmor.txt
+++ b/promtail/apparmor.txt
@@ -29,7 +29,7 @@ profile promtail flags=(attach_disconnected,mediate_deleted) {
   @{do_run}/s6/**                     rwix,
   @{do_run}/**                        rwk,
   /dev/tty                            rw,
-  @{fs_root}/usr/lib/locale/{,**}     r,
+  @{do_usr}/lib/locale/{,**}          r,
   @{do_etc_ro}/group                  r,
   @{do_etc_ro}/passwd                 r,
   @{do_etc_ro}/hosts                  r,


### PR DESCRIPTION
Tiny change to use the `do_usr` variable instead of `@{fs_root}/usr/`