### PR TITLE
aa - Remove references to run and etc globals

### DIFF
--- a/promtail/apparmor.txt
+++ b/promtail/apparmor.txt
@@ -2,64 +2,61 @@ include <tunables/global>
 
 # Docker overlay
 @{fs_root}=/ /docker/overlay2/*/diff/
-@{do_etc_rw}=@{fs_root}/@{etc_rw}/
-@{do_etc_ro}=@{fs_root}/@{etc_ro}/
-@{do_run}=@{fs_root}/@{run}/
+@{do_etc}=@{fs_root}/etc/
+@{do_opt}=@{fs_root}/opt/
+@{do_run}=@{fs_root}/{run,var/run}/
 @{do_usr}=@{fs_root}/usr/
 @{do_var}=@{fs_root}/var/
 
 # Systemd Journal location
-@{journald}=/var/log/journal/{,**} @{run}/log/journal/{,**}
+@{journald}=/var/log/journal/{,**} /run/log/journal/{,**}
 
 profile promtail flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
+  include <abstractions/bash>
 
   # Send signals to children
   signal (send) set=(kill,term,int,hup,cont),
 
   # S6-Overlay
-  /init                               rix,
-  /bin/**                             rix,
-  /usr/bin/**                         rix,
-  @{do_etc_ro}/s6/**                  rix,
-  @{do_etc_rw}/services.d/{,**}       rwix,
-  @{do_etc_rw}/cont-init.d/{,**}      rwix,
-  @{do_etc_rw}/cont-finish.d/{,**}    rwix,
-  @{do_etc_rw}/fix-attrs.d/{,**}      rw,
-  @{do_run}/s6/**                     rwix,
-  @{do_run}/**                        rwk,
-  /dev/tty                            rw,
-  @{do_usr}/lib/locale/{,**}          r,
-  @{do_etc_ro}/group                  r,
-  @{do_etc_ro}/passwd                 r,
-  @{do_etc_ro}/hosts                  r,
-  @{do_etc_ro}/ssl/openssl.cnf        r,
-  @{do_etc_ro}/host.conf              r,
-  @{do_etc_ro}/nsswitch.conf          r,
-  @{do_etc_ro}/resolv.conf            r,
-  /dev/null                           k,
+  /init                            rix,
+  /bin/**                          rix,
+  /usr/bin/**                      rix,
+  @{do_etc}/s6/**                  rix,
+  @{do_etc}/services.d/{,**}       rwix,
+  @{do_etc}/cont-init.d/{,**}      rwix,
+  @{do_etc}/cont-finish.d/{,**}    rwix,
+  @{do_etc}/fix-attrs.d/{,**}      rw,
+  @{do_run}/s6/**                  rwix,
+  @{do_run}/**                     rwk,
+  /dev/tty                         rw,
+  @{do_usr}/lib/locale/{,**}       r,
+  @{do_etc}/group                  r,
+  @{do_etc}/passwd                 r,
+  @{do_etc}/hosts                  r,
+  @{do_etc}/ssl/openssl.cnf        r,
+  @{do_etc}/host.conf              r,
+  @{do_etc}/nsswitch.conf          r,
+  @{do_etc}/resolv.conf            r,
+  /dev/null                        k,
 
   # Bashio
-  /usr/lib/bashio/**                  ix,
-  /tmp/**                             rw,
+  /usr/lib/bashio/**               ix,
+  /tmp/**                          rw,
 
   # Options.json & addon data
-  /data                               r,
-  /data/**                            rw,
+  /data                            r,
+  /data/**                         rw,
 
   # Files needed for setup
-  @{do_etc_rw}/promtail/{,**}         rw,
-  /share/{,**}                        r,
-  /ssl/{,**}                          r,
-  @{journald}                         r,
+  @{do_etc}/promtail/{,**}         rw,
+  /share/{,**}                     r,
+  /ssl/{,**}                       r,
+  @{journald}                      r,
 
   # Programs
-  /usr/bin/promtail                   cx,
-  /usr/bin/yq                         Cx,
-
-  # Shell access
-  owner @{HOME}/.*                    rw,
-  @{do_etc_ro}/bash.bashrc            r,
+  /usr/bin/promtail                cx,
+  /usr/bin/yq                      Cx,
 
   profile /usr/bin/promtail flags=(attach_disconnected,mediate_deleted) {
     include <abstractions/base>
@@ -72,38 +69,38 @@ profile promtail flags=(attach_disconnected,mediate_deleted) {
     network tcp,
 
     # Addon data
-    /data/**                          r,
-    /data/promtail/**                 rwk,
+    /data/**                       r,
+    /data/promtail/**              rwk,
 
     # Log sources
-    @{journald}                       r,
-    /share/**                         r,
+    @{journald}                    r,
+    /share/**                      r,
 
     # Config
-    @{do_etc_ro}/promtail/config.yaml r,
-    /ssl/**                           r,
+    @{do_etc}/promtail/config.yaml r,
+    /ssl/**                        r,
 
     # Runtime usage
-    /usr/bin/promtail                 rm,
-    @{do_etc_ro}/hosts                r,
-    @{do_etc_ro}/resolv.conf          r,
-    @{do_etc_ro}/passwd               r,
-    @{do_etc_ro}/nsswitch.conf        r,
-    @{PROC}/sys/net/core/somaxconn    r,
+    /usr/bin/promtail              rm,
+    @{do_etc}/hosts                r,
+    @{do_etc}/resolv.conf          r,
+    @{do_etc}/passwd               r,
+    @{do_etc}/nsswitch.conf        r,
+    @{PROC}/sys/net/core/somaxconn r,
     @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size r,
-    /dev/null                         k,
+    /dev/null                      k,
   }
 
   profile /usr/bin/yq flags=(attach_disconnected,mediate_deleted) {
     include <abstractions/base>
 
     # Config files
-    @{do_etc_rw}/promtail/*           rw,
-    /share/**                         r,
+    @{do_etc}/promtail/*           rw,
+    /share/**                      r,
 
     # Runtime usage
-    /usr/bin/yq                       rm,
+    /usr/bin/yq                    rm,
     @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size r,
-    /dev/null                         k,
+    /dev/null                      k,
   }
 }


### PR DESCRIPTION
Remove references to `run`, `etc_ro` and `etc_rw` variables as it seems like we can't always rely on them coming in from `tunables/global`. Perhaps they are newer? Regardless, minor change that allows more systems to load the profile without error.

Also realized there is a generic `abstractions/bash` so using that instead of my random guesses at what bash needs if users happen to exec into the container.