### PR TITLE
Bump addons debian base from `4.1.4` to `4.2.0`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,5 +1,4 @@
-# https://github.com/hassio-addons/addon-debian-base/releases
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:4.1.4
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64
 ARG BUILD_ARCH=amd64
 
 # https://github.com/mdegat01/promtail-journal/releases
@@ -31,8 +30,8 @@ RUN set -eux; \
     chmod a+x /usr/bin/yq; \
     rm /tmp/yq.tar.gz;
 
-# hadolint ignore=DL3006
-FROM ${BUILD_FROM}
+# https://github.com/hassio-addons/addon-debian-base/releases
+FROM ${BUILD_FROM}:4.2.0
 
 # tzdata required for the timestamp stage to work
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression

--- a/promtail/build.json
+++ b/promtail/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "amd64": "ghcr.io/hassio-addons/debian-base/amd64:4.1.4",
-    "armhf": "ghcr.io/hassio-addons/debian-base/armhf:4.1.4",
-    "armv7": "ghcr.io/hassio-addons/debian-base/armv7:4.1.4",
-    "aarch64": "ghcr.io/hassio-addons/debian-base/aarch64:4.1.4"
+    "amd64": "ghcr.io/hassio-addons/debian-base/amd64",
+    "armhf": "ghcr.io/hassio-addons/debian-base/armhf",
+    "armv7": "ghcr.io/hassio-addons/debian-base/armv7",
+    "aarch64": "ghcr.io/hassio-addons/debian-base/aarch64"
   }
 }


### PR DESCRIPTION
Bumps hassio-addons/debian-base image from `4.1.4` to [4.2.0](https://github.com/hassio-addons/addon-debian-base/releases/tag/v4.2.0)