### PR TITLE
Bump YQ to `v4.8.0`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -7,7 +7,7 @@ FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.0.0 as build_promtail
 # https://hub.docker.com/_/alpine
 FROM alpine:3.13.5 as build_yq
 # https://github.com/mikefarah/yq/releases
-ENV YQ_VERSION 4.7.1
+ENV YQ_VERSION 4.8.0
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Bump YQ version from `v4.7.1` to [v4.8.0](https://github.com/mikefarah/yq/releases/tag/v4.8.0