### PR TITLE
Bump YQ to `4.9.1`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -7,7 +7,7 @@ FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.0.0 as build_promtail
 # https://hub.docker.com/_/alpine
 FROM alpine:3.13.5 as build_yq
 # https://github.com/mikefarah/yq/releases
-ENV YQ_VERSION 4.9.0
+ENV YQ_VERSION 4.9.1
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Bump YQ version from `4.9.0` to [4.9.1](https://github.com/mikefarah/yq/releases/tag/v4.9.1)