### PR TITLE
Bump promtail journal base to `1.0.1`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64
 ARG BUILD_ARCH=amd64
 
 # https://github.com/mdegat01/promtail-journal/releases
-FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.0.0 as build_promtail
+FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.0.1 as build_promtail
 
 # https://hub.docker.com/_/alpine
 FROM alpine:3.13.5 as build_yq


### PR DESCRIPTION
Bump promtail journal from `1.0.0` to [1.0.1](https://github.com/mdegat01/promtail-journal/releases/tag/v1.0.1)