### PR TITLE
Bump YQ to `4.11.0`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -7,7 +7,7 @@ FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.0.1 as build_promtail
 # https://hub.docker.com/_/alpine
 FROM alpine:3.14.0 as build_yq
 # https://github.com/mikefarah/yq/releases
-ENV YQ_VERSION 4.10.0
+ENV YQ_VERSION 4.11.0
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Bump YQ from `4.10.0` to [4.11.0](https://github.com/mikefarah/yq/releases/tag/v4.11.0)