### PR TITLE
Update promtail-journal to `1.1.0`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64
 ARG BUILD_ARCH=amd64
 
 # https://github.com/mdegat01/promtail-journal/releases
-FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.0.1 as build_promtail
+FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.1.0 as build_promtail
 
 # https://hub.docker.com/_/alpine
 FROM alpine:3.14.1 as build_yq


### PR DESCRIPTION
Update promtail-journal from `1.0.1` to [1.1.0](https://github.com/mdegat01/promtail-journal/releases/tag/v1.1.0). This will also update promtail from `2.2.1` to [2.3.0](https://github.com/grafana/loki/releases/tag/v2.3.0)