### PR TITLE
Bump addon debian base to `4.2.3`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
     rm /tmp/yq.tar.gz;
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ${BUILD_FROM}:4.2.2
+FROM ${BUILD_FROM}:4.2.3
 
 # tzdata required for the timestamp stage to work
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression


### PR DESCRIPTION
Bump addon debian base from `4.2.2` to [4.2.3](https://github.com/hassio-addons/addon-debian-base/releases/tag/v4.2.3)