### PR TITLE
Update addon debian base to `5.1.0`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
     rm /tmp/yq.tar.gz;
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ${BUILD_FROM}:5.0.0
+FROM ${BUILD_FROM}:5.1.0
 
 # tzdata required for the timestamp stage to work
 RUN set -eux; \


### PR DESCRIPTION
Update addon debian base from `5.0.0` to [5.1.0](https://github.com/hassio-addons/addon-debian-base/releases/tag/v5.1.0)