### PR TITLE
Bump addon debian base to `5.1.1`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
     rm /tmp/yq.tar.gz;
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ${BUILD_FROM}:5.1.0
+FROM ${BUILD_FROM}:5.1.1
 
 # tzdata required for the timestamp stage to work
 RUN set -eux; \


### PR DESCRIPTION
Bump addon debian base from `5.1.0` to [5.1.1](https://github.com/hassio-addons/addon-debian-base/releases/tag/v5.1.1)