### PR TITLE
Bump addon debian base to `5.2.0`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
     rm /tmp/yq.tar.gz;
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ${BUILD_FROM}:5.1.1
+FROM ${BUILD_FROM}:5.2.0
 
 # tzdata required for the timestamp stage to work
 RUN set -eux; \

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -37,7 +37,7 @@ FROM ${BUILD_FROM}:5.2.0
 RUN set -eux; \
     apt-get update; \
     apt-get install -qy --no-install-recommends \ 
-        tzdata=2021a-1 \
+        tzdata=2021a-1+deb11u1 \
         ca-certificates=20210119 \
         libsystemd-dev=247.3-6 \
         ; \


### PR DESCRIPTION
Bump addon debian base from `5.1.1` to [5.2.0](https://github.com/hassio-addons/addon-debian-base/releases/tag/v5.2.0). Also bumps to current version of tzdata (`2021a-1+deb11u1`)