### PR TITLE
Update to Promtail `2.4.1`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64
 ARG BUILD_ARCH=amd64
 
 # https://github.com/mdegat01/promtail-journal/releases
-FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.2.1 as build_promtail
+FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.3.0 as build_promtail
 
 # https://hub.docker.com/_/alpine
 FROM alpine:3.14.2 as build_yq


### PR DESCRIPTION
Update promtail journal base from `1.2.1` to [1.3.0](https://github.com/mdegat01/promtail-journal/releases/tag/v1.3.0). This also updates Promtail from `2.3.0` to [2.4.1](https://github.com/grafana/loki/releases/tag/v2.4.1) (note this covers the more significant bump to minor version [2.4.0](https://github.com/grafana/loki/releases/tag/v2.4.0))