### PR TITLE
Don't pass `GITHUB_TOKEN` to labels workflow

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/labels.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Appears there is no need to explicitly pass `GITHUB_TOKEN` as input in workflow calls.
