### PR TITLE
Bump addon debian base to `5.2.3`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
     rm /tmp/yq.tar.gz;
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ${BUILD_FROM}:5.2.2
+FROM ${BUILD_FROM}:5.2.3
 
 # tzdata required for the timestamp stage to work
 RUN set -eux; \


### PR DESCRIPTION
Bump addon debian base from `5.2.2` to [5.2.3](https://github.com/hassio-addons/addon-debian-base/releases/tag/v5.2.3)
