### PR TITLE
Update to promtail journal `1.4.0`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64
 ARG BUILD_ARCH=amd64
 
 # https://github.com/mdegat01/promtail-journal/releases
-FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.3.0 as build_promtail
+FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.4.0 as build_promtail
 
 # https://hub.docker.com/_/alpine
 FROM alpine:3.15.0 as build_yq


### PR DESCRIPTION
Update promtail journal from `1.3.0` to [1.4.0](https://github.com/mdegat01/promtail-journal/releases/tag/v1.4.0). Primarily contains an update to promtail, going from version `2.4.1` to [2.4.2](https://github.com/grafana/loki/releases/tag/v2.4.2).
