### PR TITLE
Bump hassio-addons/debian-base to `5.3.1`

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -31,7 +31,8 @@ RUN set -eux; \
     rm /tmp/yq.tar.gz;
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ${BUILD_FROM}:5.3.1
+# hadolint ignore=DL3006
+FROM ${BUILD_FROM}
 
 # tzdata required for the timestamp stage to work
 RUN set -eux; \

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
     rm /tmp/yq.tar.gz;
 
 # https://github.com/hassio-addons/addon-debian-base/releases
-FROM ${BUILD_FROM}:5.2.3
+FROM ${BUILD_FROM}:5.3.1
 
 # tzdata required for the timestamp stage to work
 RUN set -eux; \

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -37,7 +37,7 @@ FROM ${BUILD_FROM}:5.3.1
 RUN set -eux; \
     apt-get update; \
     apt-get install -qy --no-install-recommends \ 
-        tzdata=2021a-1+deb11u2 \
+        tzdata=2021a-1+deb11u3 \
         ca-certificates=20210119 \
         libsystemd-dev=247.3-7 \
         ; \

--- a/promtail/build.yaml
+++ b/promtail/build.yaml
@@ -1,6 +1,6 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/debian-base/amd64
-  armhf: ghcr.io/hassio-addons/debian-base/armhf
-  armv7: ghcr.io/hassio-addons/debian-base/armv7
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:5.3.1
+  armhf: ghcr.io/hassio-addons/debian-base/armhf:5.3.1
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:5.3.1
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:5.3.1


### PR DESCRIPTION
Bump hassio-addons/debian-base from `5.2.3` to [5.3.1](https://github.com/hassio-addons/addon-debian-base/releases/tag/v5.3.1)

Required package bumps:
- Bump tzdata from `2021a-1+deb11u2` to `2021a-1+deb11u3`