### PR TITLE
Allow /config access to promtail folder only

### DIFF
--- a/promtail/DOCS.md
+++ b/promtail/DOCS.md
@@ -110,8 +110,11 @@ at the start of each log line for color-coding in terminals. Looking for that
 in a multiline stage makes it so tracebacks are included in the same log entry
 as the error that caused them for easier readability.
 
-See the [promtail documenation][promtail-doc-stages] for more information on how
+See the [promtail documentation][promtail-doc-stages] for more information on how
 to configure pipeline stages.
+
+**Note**: This addon has access to `/ssl`, `/share` and `/config/promtail`. Place
+the file in one of these locations, others will not work.
 
 ### Option: `skip_default_scrape_config`
 
@@ -120,6 +123,9 @@ find [here][addon-default-config]. If you only want it to look at specific log
 files you specify or you don't like the default config and want to adjust it, set
 this to `true`. Then the only scrape configs used will be the ones you specify
 in the `additional_scrape_configs` file.
+
+**Note**: This addon has access to `/ssl`, `/share` and `/config/promtail`. Place
+the file in one of these locations, others will not work.
 
 ### Option: `additional_scrape_configs`
 
@@ -156,6 +162,9 @@ I would also recommend reading the [Loki best practices][loki-doc-best-practices
 guide before making custom scrape configs. Pipelines are pretty powerful but
 avoid making too many labels, it does more harm then good. Instead look into
 what you can do with [LogQL][logql] can do at the other end.
+
+**Note**: This addon has access to `/ssl`, `/share` and `/config/promtail`. Place
+the file in one of these locations, others will not work.
 
 ### Port: `9080/tcp`
 

--- a/promtail/apparmor.txt
+++ b/promtail/apparmor.txt
@@ -50,6 +50,7 @@ profile promtail flags=(attach_disconnected,mediate_deleted) {
 
   # Files needed for setup
   @{do_etc}/promtail/{,**}                rw,
+  /config/promtail/{,**}                  r,
   /{share,ssl}/{,**}                      r,
   @{journald}                             r,
 
@@ -75,6 +76,7 @@ profile promtail flags=(attach_disconnected,mediate_deleted) {
 
     # Config & log data
     @{do_etc}/promtail/config.yaml        r,
+    /config/promtail/{,**}                r,
     /{share,ssl}/**                       r,
     @{journald}                           r,
 
@@ -93,6 +95,7 @@ profile promtail flags=(attach_disconnected,mediate_deleted) {
 
     # Config files
     @{do_etc}/promtail/*                  rw,
+    /config/promtail/{,**}                r,
     /share/**                             r,
 
     # Runtime usage

--- a/promtail/config.yaml
+++ b/promtail/config.yaml
@@ -11,6 +11,7 @@ arch:
 description: Promtail for Home Assistant
 journald: true
 map:
+  - config
   - share
   - ssl
 watchdog: http://[HOST]:[PORT:9080]/ready


### PR DESCRIPTION
# Proposed Changes

Allow access to /config/promtail for users that wish to store all config in /config. Apparmor profile blocks access to all other files in /config outside of this profile to prevent ability to read secrets and other secure information.

## Related Issues

Fixes #185 
