### PR TITLE
Add /tmp access to promtail apparmor profile

### DIFF
--- a/promtail/apparmor.txt
+++ b/promtail/apparmor.txt
@@ -70,6 +70,9 @@ profile promtail flags=(attach_disconnected,mediate_deleted) {
     network netlink raw,
     network unix dgram,
 
+    # Temp files
+    /tmp/.positions.yaml*                 rw,
+
     # Addon data
     /data/**                              r,
     /data/promtail/**                     rwk,


### PR DESCRIPTION
# Proposed Changes

Resolve `apparmor="DENIED"` messages for the promtail process in system logs

## Related Issues

https://github.com/mdegat01/addon-promtail/issues/199