### PR TITLE
Bump yq to 4.25.3

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,9 +1,8 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64
 ARG BUILD_ARCH=amd64
-ARG PROMTAIL_JOURNAL_VERSION=1.5.0
 
 # https://github.com/mdegat01/promtail-journal/releases
-FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:${PROMTAIL_JOURNAL_VERSION} as build_promtail
+FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.5.0 as build_promtail
 
 # https://github.com/hassio-addons/addon-debian-base/releases
 # hadolint ignore=DL3006
@@ -11,7 +10,7 @@ FROM ${BUILD_FROM}
 
 ARG BUILD_ARCH=amd64
 # https://github.com/mikefarah/yq/releases
-ARG YQ_VERSION=4.24.5
+ENV YQ_VERSION=4.25.3
 
 # Add yq and tzdata (required for the timestamp stage)
 RUN set -eux; \

--- a/promtail/build.yaml
+++ b/promtail/build.yaml
@@ -8,5 +8,5 @@ codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com
 args:
-  PROMTAIL_JOURNAL_VERSION: 1.5.0
-  YQ_VERSION: 4.24.5
+  PROMTAIL_JOURNAL_VERSION: "1.5.0"
+  YQ_VERSION: "4.25.3"

--- a/promtail/build.yaml
+++ b/promtail/build.yaml
@@ -7,6 +7,3 @@ build_from:
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com
-args:
-  PROMTAIL_JOURNAL_VERSION: "1.5.0"
-  YQ_VERSION: "4.25.3"


### PR DESCRIPTION
Bump yq from `4.24.5` to [4.25.3](https://github.com/mikefarah/yq/releases/tag/v4.25.3)