### PR TITLE
Bump addon debian base 6.1.1

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux; \
     apt-get install -qy --no-install-recommends \ 
         tar=1.34+dfsg-1 \
         curl=7.74.0-1.3+deb11u1 \
-        tzdata=2021a-1+deb11u3 \
+        tzdata=2021a-1+deb11u4 \
         ca-certificates=20210119 \
         libsystemd-dev=247.3-7 \
         ; \

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -17,9 +17,6 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -qy --no-install-recommends \ 
         tar=1.34+dfsg-1 \
-        curl=7.74.0-1.3+deb11u1 \
-        tzdata=2021a-1+deb11u4 \
-        ca-certificates=20210119 \
         libsystemd-dev=247.3-7 \
         ; \
     update-ca-certificates; \

--- a/promtail/build.yaml
+++ b/promtail/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/debian-base/amd64:6.0.0
-  armhf: ghcr.io/hassio-addons/debian-base/armhf:6.0.0
-  armv7: ghcr.io/hassio-addons/debian-base/armv7:6.0.0
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:6.0.0
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:6.1.1
+  armhf: ghcr.io/hassio-addons/debian-base/armhf:6.1.1
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:6.1.1
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:6.1.1
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com


### PR DESCRIPTION
Bump addon debian base from [6.0.0 to 6.1.1](https://github.com/hassio-addons/addon-debian-base/compare/v5.3.1...v6.1.1)