### PR TITLE
Update to promtail 2.6.1

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -17,6 +17,7 @@ RUN set -eux; \
     apt-get install -qy --no-install-recommends \ 
         tar=1.34+dfsg-1 \
         libsystemd-dev=247.3-7 \
+        unzip=6.0-26 \
         ; \
     update-ca-certificates; \
     \

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,6 +1,9 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64
 ARG BUILD_ARCH=amd64
 
+# https://github.com/grafana/loki/releases
+FROM grafana/promtail:2.6.1 as build_promtail
+
 # https://github.com/hassio-addons/addon-debian-base/releases
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
@@ -17,7 +20,6 @@ RUN set -eux; \
     apt-get install -qy --no-install-recommends \ 
         tar=1.34+dfsg-1 \
         libsystemd-dev=247.3-7 \
-        unzip=6.0-26 \
         ; \
     update-ca-certificates; \
     \
@@ -36,16 +38,11 @@ RUN set -eux; \
     rm /tmp/yq.tar.gz; \
     yq --version; \
     \
-    curl -s -J -L -o /tmp/promtail.zip \
-        "https://github.com/grafana/loki/releases/download/v${PROMTAIL_VERSION}/promtail-linux-${BINARCH}.zip"; \
-    unzip /tmp/promtail.zip -d /usr/bin; \
-    mv /usr/bin/promtail-linux-${BINARCH} /usr/bin/promtail; \
-    chmod a+x /usr/bin/promtail; \
-    rm /tmp/promtail.zip; \
-    promtail --version; \
-    \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*;
+
+COPY --from=build_promtail /usr/bin/promtail /usr/bin/promtail
+RUN promtail --version
 
 COPY rootfs /
 WORKDIR /data/promtail

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -35,12 +35,12 @@ RUN set -eux; \
     rm /tmp/yq.tar.gz; \
     yq --version; \
     \
-    curl -s -J -L -o /tmp/promtail.tar.gz \
+    curl -s -J -L -o /tmp/promtail.zip \
         "https://github.com/grafana/loki/releases/download/v${PROMTAIL_VERSION}/promtail-linux-${BINARCH}.zip"; \
-    tar -xf /tmp/promtail.tar.gz -C /usr/bin; \
+    unzip /tmp/promtail.zip -d /usr/bin; \
     mv /usr/bin/promtail-linux-${BINARCH} /usr/bin/promtail; \
     chmod a+x /usr/bin/promtail; \
-    rm /tmp/promtail.tar.gz; \
+    rm /tmp/promtail.zip; \
     promtail --version; \
     \
     apt-get clean; \

--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -1,9 +1,6 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64
 ARG BUILD_ARCH=amd64
 
-# https://github.com/mdegat01/promtail-journal/releases
-FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.5.0 as build_promtail
-
 # https://github.com/hassio-addons/addon-debian-base/releases
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
@@ -11,6 +8,8 @@ FROM ${BUILD_FROM}
 ARG BUILD_ARCH=amd64
 # https://github.com/mikefarah/yq/releases
 ARG YQ_VERSION=4.27.3
+# https://github.com/grafana/loki/releases
+ARG PROMTAIL_VERSION=2.6.1
 
 # Add yq and tzdata (required for the timestamp stage)
 RUN set -eux; \
@@ -36,12 +35,16 @@ RUN set -eux; \
     rm /tmp/yq.tar.gz; \
     yq --version; \
     \
+    curl -s -J -L -o /tmp/promtail.tar.gz \
+        "https://github.com/grafana/loki/releases/download/v${PROMTAIL_VERSION}/promtail-linux-${BINARCH}.zip"; \
+    tar -xf /tmp/promtail.tar.gz -C /usr/bin; \
+    mv /usr/bin/promtail-linux-${BINARCH} /usr/bin/promtail; \
+    chmod a+x /usr/bin/promtail; \
+    rm /tmp/promtail.tar.gz; \
+    promtail --version; \
+    \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*;
-
-# Add promtail
-COPY --from=build_promtail /usr/bin/promtail /usr/bin/promtail
-RUN promtail --version
 
 COPY rootfs /
 WORKDIR /data/promtail

--- a/promtail/build.yaml
+++ b/promtail/build.yaml
@@ -1,7 +1,6 @@
 ---
 build_from:
   amd64: ghcr.io/hassio-addons/debian-base/amd64:6.1.1
-  armhf: ghcr.io/hassio-addons/debian-base/armhf:6.1.1
   armv7: ghcr.io/hassio-addons/debian-base/armv7:6.1.1
   aarch64: ghcr.io/hassio-addons/debian-base/aarch64:6.1.1
 codenotary:

--- a/promtail/config.yaml
+++ b/promtail/config.yaml
@@ -7,7 +7,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-  - armhf
 description: Promtail for Home Assistant
 codenotary: codenotary@degatano.com
 init: false


### PR DESCRIPTION
~~It appears that grafana is building the promtail release binaries with journal support now so we attempt to use them again.~~

Still doesn't. But the one in the published image on [dockerhub](https://hub.docker.com/r/grafana/promtail/tags) does so we're going to switch to that.