### PR TITLE
Update promtail to 2.6.1

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64
 ARG BUILD_ARCH=amd64
 
 # https://github.com/mdegat01/promtail-journal/releases
-FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.5.0 as build_promtail
+FROM ghcr.io/mdegat01/promtail-journal/${BUILD_ARCH}:1.6.0 as build_promtail
 
 # https://github.com/hassio-addons/addon-debian-base/releases
 # hadolint ignore=DL3006


### PR DESCRIPTION
Bump promtail journal base to [1.6.0](https://github.com/mdegat01/promtail-journal/releases/tag/v1.6.0) (which updates Promtail to [2.6.1](https://github.com/grafana/loki/releases/tag/v2.6.1))