### PR TITLE
Update nodename label to hostname

### DIFF
--- a/promtail/rootfs/etc/promtail/default-scrape-config.yaml
+++ b/promtail/rootfs/etc/promtail/default-scrape-config.yaml
@@ -12,7 +12,7 @@
       target_label: unit
     - source_labels:
         - __journal__hostname
-      target_label: nodename
+      target_label: hostname
     - source_labels:
         - __journal_syslog_identifier
       target_label: syslog_identifier


### PR DESCRIPTION
Hey

I've been wondering if it would not be a better idea to relabel `__journal__hostname` into `hostname` rather than `nodename` which seems more specific to the Kubernetes node concept.

Would you agree?