### PR TITLE
Bump debian base to 6.1.3

### DIFF
--- a/promtail/Dockerfile
+++ b/promtail/Dockerfile
@@ -17,7 +17,7 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -qy --no-install-recommends \ 
         tar=1.34+dfsg-1 \
-        libsystemd-dev=247.3-7 \
+        libsystemd-dev=247.3-7+deb11u1 \
         ; \
     update-ca-certificates; \
     \

--- a/promtail/build.yaml
+++ b/promtail/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/debian-base/amd64:6.1.1
-  armhf: ghcr.io/hassio-addons/debian-base/armhf:6.1.1
-  armv7: ghcr.io/hassio-addons/debian-base/armv7:6.1.1
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:6.1.1
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:6.1.3
+  armhf: ghcr.io/hassio-addons/debian-base/armhf:6.1.3
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:6.1.3
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:6.1.3
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com


### PR DESCRIPTION
Bump debian base from `6.1.1` to [`6.1.3`](https://github.com/hassio-addons/addon-debian-base/releases/tag/v6.1.3).

Also bump `libsystemd-dev` package.
